### PR TITLE
Add LICENSE files to eslint-config-js and stylelint-config-scss packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "root",
+  "license": "MIT",
   "private": true,
   "dependencies": {
     "lerna": "^4.0.0"

--- a/packages/eslint-config-js/LICENSE
+++ b/packages/eslint-config-js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Infinum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@infinumrails/eslint-config-js",
+  "license": "MIT",
   "version": "0.1.0",
   "main": "index.js",
   "repository": {

--- a/packages/stylelint-config-scss/LICENSE
+++ b/packages/stylelint-config-scss/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Infinum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/stylelint-config-scss/package.json
+++ b/packages/stylelint-config-scss/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@infinumrails/stylelint-config-scss",
+  "license": "MIT",
   "version": "0.1.0",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
We need to add the license to each package because we are referencing each package separately.